### PR TITLE
feat: add before:offline:start lifecycle event

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ class serverlessPluginIfElse {
         this.hooks = {
             "before:package:initialize": this.applyConditions.bind(this),
             "before:offline:start:init": this.applyConditions.bind(this),
+            "before:offline:start": this.applyConditions.bind(this),
         };
         this.pluginName = "serverless-plugin-ifelse";
     }


### PR DESCRIPTION
Hey @anantab, this change will allow for the plugin to register in v6+ of serverless-offline when started with the command `serverless offline`, currently it will only work with `serverless offline start`.

Thank you for the plugin, it's fab!

I have published a version with this change in under `@you54f/serverless-plugin-ifelse` that you can test.

Thanks,

Saf