### PR TITLE
feat: add before:remove:remove lifecycle event

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ class serverlessPluginIfElse {
         this.options = options;
         this.hooks = {
             "before:package:initialize": this.applyConditions.bind(this),
+            "before:remove:remove": this.applyConditions.bind(this),
             "before:offline:start:init": this.applyConditions.bind(this),
             "before:offline:start": this.applyConditions.bind(this),
         };


### PR DESCRIPTION
There are some variables that need to be set up before removing too. For example, I'm using `serverless-domain-manager`. When deploying for the stage `'dev'`, I use `api.example.xyz` and when deploying for stage `'prod'` it should be `'api.example.com'`. It can be achieved without a problem.

But the problem is when using `sls remove -s prod`. When running that command this plugin does not fire, resulting the domain name to be `api.example.xyz.` This is problematic when detaching the api-mappings because dev and prod are in two separate AWS accounts. Even being in the same account will cause errors.

So it's best to fire the plugin in before:remove:remove lifecycle event.

