### PR TITLE
add support for array

### DIFF
--- a/index.js
+++ b/index.js
@@ -113,7 +113,11 @@ class serverlessPluginIfElse {
         if (path[i] in item) {
             if (type == "remove") {
                 this.serverless.cli.log(this.pluginName + " - Excluding: " + keyPath);
-                delete item[path[i]];
+                if (Array.isArray(item)) {
+                    item.splice(parseInt(path[i]), 1);
+                } else {
+                    delete item[path[i]];
+                }
             } else if (type == "set") {
                 item[path[i]] = newValue;
                 if (typeof newValue == "object") {


### PR DESCRIPTION
Hi,

Thank you for this amazing library. It has truly made my life much simpler. 

Currently, if I exclude an array element, it is replaced with null. For a certain use case my Cloudformation template breaks due to the null replacement. Hence if the item is an array I iterate over it and splice the index that isn't required